### PR TITLE
feat: Convert GNOME extension to TypeScript (#71, #72)

### DIFF
--- a/gnome-extension/.gitignore
+++ b/gnome-extension/.gitignore
@@ -1,0 +1,19 @@
+# Dependencies
+node_modules/
+
+# Build output
+dist/
+
+# npm
+package-lock.json
+npm-debug.log*
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+
+# OS
+.DS_Store
+Thumbs.db

--- a/gnome-extension/README.md
+++ b/gnome-extension/README.md
@@ -2,6 +2,40 @@
 
 GNOME Shell extension that exports desktop workspace, window, and application state via D-Bus.
 
+## Development
+
+### Prerequisites
+
+- Node.js 20+
+- npm
+
+### Build from TypeScript
+
+```bash
+cd gnome-extension
+npm install
+npm run build
+```
+
+### Watch Mode (auto-rebuild on changes)
+
+```bash
+npm run watch
+```
+
+### Deploy to GNOME Shell
+
+```bash
+npm run build
+cp dist/extension.js metadata.json ~/.local/share/gnome-shell/extensions/focus-tracker@olbrasoft.cz/
+```
+
+Then reload GNOME Shell:
+- **X11:** Alt+F2 → type `r` → Enter
+- **Wayland:** `gnome-extensions disable focus-tracker@olbrasoft.cz && gnome-extensions enable focus-tracker@olbrasoft.cz`
+
+---
+
 ## Status: Phase 2 - Complete
 
 **Current features:**

--- a/gnome-extension/package.json
+++ b/gnome-extension/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "focus-tracker-extension",
+  "version": "1.0.0",
+  "description": "GNOME Shell extension for desktop state tracking via D-Bus",
+  "type": "module",
+  "scripts": {
+    "build": "tsc",
+    "watch": "tsc --watch",
+    "clean": "rm -rf dist",
+    "lint": "eslint src/**/*.ts",
+    "prebuild": "npm run clean"
+  },
+  "devDependencies": {
+    "typescript": "^5.7.2"
+  },
+  "engines": {
+    "node": ">=20.0.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Olbrasoft/LinuxDesktop.git"
+  },
+  "keywords": [
+    "gnome-shell",
+    "extension",
+    "d-bus",
+    "typescript"
+  ],
+  "author": "Olbrasoft",
+  "license": "GPL-2.0-or-later"
+}

--- a/gnome-extension/package.json
+++ b/gnome-extension/package.json
@@ -7,7 +7,6 @@
     "build": "tsc",
     "watch": "tsc --watch",
     "clean": "rm -rf dist",
-    "lint": "eslint src/**/*.ts",
     "prebuild": "npm run clean"
   },
   "devDependencies": {

--- a/gnome-extension/src/extension.ts
+++ b/gnome-extension/src/extension.ts
@@ -1,10 +1,32 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Desktop State Tracker - Phase 2: Window & Application tracking
+// Desktop State Tracker - GNOME Shell Extension
+// Provides D-Bus API for desktop context awareness
+
+// Type declarations are in gjs.d.ts
+/// <reference path="./gjs.d.ts" />
 
 import Gio from 'gi://Gio';
 import GLib from 'gi://GLib';
 import Shell from 'gi://Shell';
-import {Extension} from 'resource:///org/gnome/shell/extensions/extension.js';
+import { Extension } from 'resource:///org/gnome/shell/extensions/extension.js';
+
+// Internal types
+interface GObjectWithSignals {
+    connect(signal: string, callback: () => void): number;
+    disconnect(id: number): void;
+}
+
+interface SignalConnection {
+    object: GObjectWithSignals;
+    id: number;
+}
+
+interface DBusExportedObject {
+    export(connection: unknown, path: string): void;
+    unexport(): void;
+    emit_signal(name: string, variant: unknown): void;
+    emit_property_changed(name: string, variant: unknown): void;
+}
 
 // D-Bus interface definition
 const INTERFACE_XML = `
@@ -44,37 +66,55 @@ const INTERFACE_XML = `
   </interface>
 </node>`;
 
+/**
+ * Desktop state service providing D-Bus methods and signals
+ * for workspace, window, and cursor tracking.
+ */
 class DesktopStateService {
+    private _workspaceManager: WorkspaceManager;
+    private _display: Display;
+    private _tracker: ShellWindowTracker;
+    private _signalIds: SignalConnection[];
+    public _impl: DBusExportedObject | null = null;
+
     constructor() {
         this._workspaceManager = global.workspace_manager;
         this._display = global.display;
-        this._tracker = Shell.WindowTracker.get_default();
+        this._tracker = Shell.WindowTracker.get_default() as ShellWindowTracker;
         this._signalIds = [];
 
         log('[DesktopState] Service initialized');
 
         // Connect to workspace change signals
-        const workspaceSwitchedId = this._workspaceManager.connect('workspace-switched',
-            this._onWorkspaceChanged.bind(this));
-        this._signalIds.push({object: this._workspaceManager, id: workspaceSwitchedId});
+        const workspaceSwitchedId = this._workspaceManager.connect(
+            'workspace-switched',
+            this._onWorkspaceChanged.bind(this)
+        );
+        this._signalIds.push({ object: this._workspaceManager, id: workspaceSwitchedId });
 
-        const nWorkspacesSignalId = this._workspaceManager.connect('notify::n-workspaces',
-            this._onWorkspacesCountChanged.bind(this));
-        this._signalIds.push({object: this._workspaceManager, id: nWorkspacesSignalId});
+        const nWorkspacesSignalId = this._workspaceManager.connect(
+            'notify::n-workspaces',
+            this._onWorkspacesCountChanged.bind(this)
+        );
+        this._signalIds.push({ object: this._workspaceManager, id: nWorkspacesSignalId });
 
         // Connect to focus change signals
-        const focusWindowId = this._display.connect('notify::focus-window',
-            this._onFocusChanged.bind(this));
-        this._signalIds.push({object: this._display, id: focusWindowId});
+        const focusWindowId = this._display.connect(
+            'notify::focus-window',
+            this._onFocusChanged.bind(this)
+        );
+        this._signalIds.push({ object: this._display, id: focusWindowId });
 
-        const focusAppId = this._tracker.connect('notify::focus-app',
-            this._onFocusChanged.bind(this));
-        this._signalIds.push({object: this._tracker, id: focusAppId});
+        const focusAppId = this._tracker.connect(
+            'notify::focus-app',
+            this._onFocusChanged.bind(this)
+        );
+        this._signalIds.push({ object: this._tracker, id: focusAppId });
     }
 
-    destroy() {
+    destroy(): void {
         // Disconnect all signals
-        this._signalIds.forEach(signal => {
+        this._signalIds.forEach((signal) => {
             signal.object.disconnect(signal.id);
         });
         this._signalIds = [];
@@ -83,26 +123,26 @@ class DesktopStateService {
     }
 
     // Property getters (must return GLib.Variant for D-Bus)
-    get CurrentWorkspace() {
+    get CurrentWorkspace(): unknown {
         const index = this._workspaceManager.get_active_workspace_index();
         log(`[DesktopState] Get CurrentWorkspace: ${index}`);
         return GLib.Variant.new_int32(index);
     }
 
-    get TotalWorkspaces() {
+    get TotalWorkspaces(): unknown {
         const total = this._workspaceManager.n_workspaces;
         log(`[DesktopState] Get TotalWorkspaces: ${total}`);
         return GLib.Variant.new_int32(total);
     }
 
-    get ActiveWindow() {
+    get ActiveWindow(): unknown {
         const window = this._display.focus_window;
-        const title = window ? window.get_title() : '';
+        const title = window ? window.get_title() ?? '' : '';
         log(`[DesktopState] Get ActiveWindow: ${title}`);
         return GLib.Variant.new_string(title);
     }
 
-    get ActiveApplication() {
+    get ActiveApplication(): unknown {
         const app = this._tracker.focus_app;
         const appId = app ? app.get_id() : '';
         log(`[DesktopState] Get ActiveApplication: ${appId}`);
@@ -110,7 +150,7 @@ class DesktopStateService {
     }
 
     // D-Bus Methods
-    GetWorkspaceApplications(workspaceIndex) {
+    GetWorkspaceApplications(workspaceIndex: number): unknown {
         log(`[DesktopState] GetWorkspaceApplications called for workspace: ${workspaceIndex}`);
 
         const totalWorkspaces = this._workspaceManager.n_workspaces;
@@ -129,7 +169,7 @@ class DesktopStateService {
 
         // Get all windows on this workspace
         const windows = workspace.list_windows();
-        const applications = [];
+        const applications: [string, string, string][] = [];
 
         for (const window of windows) {
             // Skip windows that shouldn't be tracked (skip_taskbar)
@@ -137,8 +177,8 @@ class DesktopStateService {
                 continue;
             }
 
-            const windowTitle = window.get_title() || '';
-            const wmClass = window.get_wm_class() || '';
+            const windowTitle = window.get_title() ?? '';
+            const wmClass = window.get_wm_class() ?? '';
 
             // Get application for this window
             const app = this._tracker.get_window_app(window);
@@ -153,13 +193,13 @@ class DesktopStateService {
         return GLib.Variant.new('a(sss)', applications);
     }
 
-    GetPointerPosition() {
+    GetPointerPosition(): unknown {
         const [x, y] = global.get_pointer();
         log(`[DesktopState] GetPointerPosition: (${x}, ${y})`);
         return GLib.Variant.new('(ii)', [x, y]);
     }
 
-    GetActiveWindowGeometry() {
+    GetActiveWindowGeometry(): unknown {
         const window = this._display.focus_window;
         if (!window) {
             log('[DesktopState] GetActiveWindowGeometry: no focused window');
@@ -172,55 +212,57 @@ class DesktopStateService {
     }
 
     // Signal handlers
-    _onWorkspaceChanged() {
+    private _onWorkspaceChanged(): void {
         const newIndex = this._workspaceManager.get_active_workspace_index();
         const total = this._workspaceManager.n_workspaces;
 
         log(`[DesktopState] Workspace changed: ${newIndex} / ${total}`);
 
         if (this._impl) {
-            this._impl.emit_signal('WorkspaceChanged',
-                new GLib.Variant('(ii)', [newIndex, total]));
+            this._impl.emit_signal('WorkspaceChanged', GLib.Variant.new('(ii)', [newIndex, total]));
         }
     }
 
-    _onWorkspacesCountChanged() {
+    private _onWorkspacesCountChanged(): void {
         const total = this._workspaceManager.n_workspaces;
 
         log(`[DesktopState] Workspaces count changed: ${total}`);
 
         // Emit property change signal
         if (this._impl) {
-            this._impl.emit_property_changed('TotalWorkspaces',
-                GLib.Variant.new_int32(total));
+            this._impl.emit_property_changed('TotalWorkspaces', GLib.Variant.new_int32(total));
         }
     }
 
-    _onFocusChanged() {
+    private _onFocusChanged(): void {
         const window = this._display.focus_window;
         const app = this._tracker.focus_app;
 
-        const windowTitle = window ? window.get_title() : '';
+        const windowTitle = window ? window.get_title() ?? '' : '';
         const appId = app ? app.get_id() : '';
-        const wmClass = window ? window.get_wm_class() : '';
+        const wmClass = window ? window.get_wm_class() ?? '' : '';
 
         log(`[DesktopState] Focus changed: ${windowTitle} (${appId}) [${wmClass}]`);
 
         if (this._impl) {
-            this._impl.emit_signal('FocusChanged',
-                new GLib.Variant('(sss)', [windowTitle, appId, wmClass]));
+            this._impl.emit_signal('FocusChanged', GLib.Variant.new('(sss)', [windowTitle, appId, wmClass]));
 
             // Also emit property changes
-            this._impl.emit_property_changed('ActiveWindow',
-                GLib.Variant.new_string(windowTitle));
-            this._impl.emit_property_changed('ActiveApplication',
-                GLib.Variant.new_string(appId));
+            this._impl.emit_property_changed('ActiveWindow', GLib.Variant.new_string(windowTitle));
+            this._impl.emit_property_changed('ActiveApplication', GLib.Variant.new_string(appId));
         }
     }
 }
 
+/**
+ * Main extension class exported to GNOME Shell.
+ */
 export default class DesktopStateExtension extends Extension {
-    enable() {
+    private _service: DesktopStateService | null = null;
+    private _ownerId: number | null = null;
+    private _exportedObject: DBusExportedObject | null = null;
+
+    enable(): void {
         log('[DesktopState] Extension enabling...');
 
         this._service = new DesktopStateService();
@@ -238,7 +280,7 @@ export default class DesktopStateExtension extends Extension {
         log('[DesktopState] Extension enabled');
     }
 
-    disable() {
+    disable(): void {
         log('[DesktopState] Extension disabling...');
 
         // Destroy service first
@@ -263,29 +305,35 @@ export default class DesktopStateExtension extends Extension {
         log('[DesktopState] Extension disabled');
     }
 
-    _onBusAcquired(connection, name) {
+    private _onBusAcquired(connection: unknown, name: string): void {
         log(`[DesktopState] Bus acquired: ${name}`);
 
         try {
             // Wrap service with D-Bus exported object
-            this._exportedObject = Gio.DBusExportedObject.wrapJSObject(INTERFACE_XML, this._service);
-            this._service._impl = this._exportedObject;
+            this._exportedObject = Gio.DBusExportedObject.wrapJSObject(
+                INTERFACE_XML,
+                this._service
+            ) as DBusExportedObject;
+
+            if (this._service) {
+                this._service._impl = this._exportedObject;
+            }
 
             // Export on D-Bus
             this._exportedObject.export(connection, '/org/olbrasoft/Desktop');
 
             log('[DesktopState] D-Bus object exported at /org/olbrasoft/Desktop');
         } catch (e) {
-            logError(e, '[DesktopState] Failed to export D-Bus object');
+            logError(e as Error, '[DesktopState] Failed to export D-Bus object');
         }
     }
 
-    _onNameAcquired(connection, name) {
+    private _onNameAcquired(_connection: unknown, name: string): void {
         log(`[DesktopState] Name acquired: ${name}`);
         log('[DesktopState] Service is now available on D-Bus!');
     }
 
-    _onNameLost(connection, name) {
+    private _onNameLost(_connection: unknown, name: string): void {
         log(`[DesktopState] Name lost: ${name}`);
         logError(new Error('Could not acquire D-Bus name'), '[DesktopState]');
     }

--- a/gnome-extension/src/gjs.d.ts
+++ b/gnome-extension/src/gjs.d.ts
@@ -1,0 +1,118 @@
+// Type declarations for GJS/GNOME Shell modules
+
+declare module 'gi://Gio' {
+    namespace Gio {
+        const BusType: {
+            SESSION: number;
+            SYSTEM: number;
+        };
+        const BusNameOwnerFlags: {
+            NONE: number;
+        };
+        function bus_own_name(
+            busType: number,
+            name: string,
+            flags: number,
+            busAcquired: (connection: unknown, name: string) => void,
+            nameAcquired: (connection: unknown, name: string) => void,
+            nameLost: (connection: unknown, name: string) => void
+        ): number;
+        function bus_unown_name(ownerId: number): void;
+        const DBusExportedObject: {
+            wrapJSObject(interfaceXml: string, object: unknown): DBusExportedObject;
+        };
+    }
+    interface DBusExportedObject {
+        export(connection: unknown, path: string): void;
+        unexport(): void;
+        emit_signal(name: string, variant: unknown): void;
+        emit_property_changed(name: string, variant: unknown): void;
+    }
+    export default Gio;
+}
+
+declare module 'gi://GLib' {
+    namespace GLib {
+        const Variant: {
+            ['new'](type: string, value: unknown): unknown;
+            new_int32(value: number): unknown;
+            new_string(value: string): unknown;
+        };
+    }
+    export default GLib;
+}
+
+declare module 'gi://Shell' {
+    namespace Shell {
+        const WindowTracker: {
+            get_default(): ShellWindowTracker;
+        };
+    }
+    export default Shell;
+}
+
+// Shell types exported globally for use in extension
+interface ShellWindowTracker {
+    focus_app: ShellApplication | null;
+    get_window_app(window: Window): ShellApplication | null;
+    connect(signal: string, callback: () => void): number;
+    disconnect(id: number): void;
+}
+
+interface ShellApplication {
+    get_id(): string;
+}
+
+declare module 'resource:///org/gnome/shell/extensions/extension.js' {
+    export class Extension {
+        enable(): void;
+        disable(): void;
+    }
+}
+
+// GNOME Shell global object
+declare const global: {
+    workspace_manager: WorkspaceManager;
+    display: Display;
+    get_pointer(): [number, number, unknown];
+};
+
+interface WorkspaceManager {
+    get_active_workspace_index(): number;
+    n_workspaces: number;
+    get_workspace_by_index(index: number): Workspace | null;
+    connect(signal: string, callback: () => void): number;
+    disconnect(id: number): void;
+}
+
+interface Workspace {
+    list_windows(): Window[];
+}
+
+interface Window {
+    get_title(): string | null;
+    get_wm_class(): string | null;
+    get_frame_rect(): Rectangle;
+    skip_taskbar: boolean;
+}
+
+interface Rectangle {
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+}
+
+interface Display {
+    focus_window: Window | null;
+    connect(signal: string, callback: () => void): number;
+    disconnect(id: number): void;
+}
+
+interface Application {
+    get_id(): string;
+}
+
+// GJS logging functions
+declare function log(message: string): void;
+declare function logError(error: Error, prefix: string): void;

--- a/gnome-extension/tsconfig.json
+++ b/gnome-extension/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": false,
+    "declaration": false,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmitOnError": false,
+    "lib": ["ES2022"],
+    "noImplicitAny": false,
+    "allowJs": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/gnome-extension/tsconfig.json
+++ b/gnome-extension/tsconfig.json
@@ -1,4 +1,8 @@
 {
+  // NOTE: strict mode is intentionally disabled for GJS/GNOME Shell compatibility.
+  // GJS modules (gi://Gio, gi://GLib) don't have proper TypeScript definitions,
+  // and strict mode would require extensive type casting throughout the code.
+  // We use custom type declarations in gjs.d.ts for basic type safety.
   "compilerOptions": {
     "target": "ES2022",
     "module": "ES2022",
@@ -10,7 +14,7 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
-    "noEmitOnError": false,
+    "noEmitOnError": true,
     "lib": ["ES2022"],
     "noImplicitAny": false,
     "allowJs": true


### PR DESCRIPTION
## Summary

- Convert GNOME Shell extension from JavaScript to TypeScript
- Add TypeScript project setup with npm build system
- Maintain full compatibility with existing D-Bus API

## Changes

### TypeScript Setup (#71)
- `package.json` - npm project with build scripts
- `tsconfig.json` - TypeScript configuration for ES2022/GJS
- `.gitignore` - Ignore node_modules and dist

### TypeScript Conversion (#72)
- `src/extension.ts` - TypeScript source with type annotations
- `src/gjs.d.ts` - Type declarations for GNOME Shell modules (Gio, GLib, Shell)
- Removed `extension.js` from root (now generated to `dist/`)

## Build

```bash
cd gnome-extension
npm install
npm run build  # Outputs dist/extension.js
```

## Test plan

- [ ] Build succeeds: `npm run build`
- [ ] Generated `dist/extension.js` is valid JavaScript
- [ ] Extension loads in GNOME Shell
- [ ] D-Bus methods work: `GetPointerPosition`, `GetActiveWindowGeometry`

## Related Issues

Closes #71
Closes #72
Part of #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)