### PR TITLE
feat: Add separate CI/CD workflows for NuGet and extension (#73)

### DIFF
--- a/.github/workflows/deploy-extension.yml
+++ b/.github/workflows/deploy-extension.yml
@@ -1,0 +1,91 @@
+name: GNOME Extension Deploy
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'gnome-extension/**'
+      - '.github/workflows/deploy-extension.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'gnome-extension/**'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20'
+
+    - name: Install dependencies
+      working-directory: ./gnome-extension
+      run: npm ci
+
+    - name: Build TypeScript
+      working-directory: ./gnome-extension
+      run: npm run build
+
+    - name: Verify build output
+      run: |
+        if [ -f gnome-extension/dist/extension.js ]; then
+          echo "✅ Build successful: extension.js generated"
+          ls -la gnome-extension/dist/
+        else
+          echo "❌ Build failed: extension.js not found"
+          exit 1
+        fi
+
+  deploy:
+    needs: build
+    runs-on: self-hosted
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20'
+
+    - name: Install dependencies
+      working-directory: ./gnome-extension
+      run: npm ci
+
+    - name: Build TypeScript
+      working-directory: ./gnome-extension
+      run: npm run build
+
+    - name: Deploy extension
+      run: |
+        TARGET=~/.local/share/gnome-shell/extensions/focus-tracker@olbrasoft.cz
+        mkdir -p $TARGET
+
+        echo "📦 Deploying extension to $TARGET"
+        cp gnome-extension/dist/extension.js $TARGET/
+        cp gnome-extension/metadata.json $TARGET/
+
+        echo "✅ Extension deployed successfully"
+        ls -la $TARGET/
+
+    - name: Verify deployment
+      run: |
+        TARGET=~/.local/share/gnome-shell/extensions/focus-tracker@olbrasoft.cz
+
+        if [ -f "$TARGET/extension.js" ] && [ -f "$TARGET/metadata.json" ]; then
+          echo "✅ Deployment verified"
+          echo "📝 NOTE: Restart GNOME Shell to load updated extension"
+          echo "   - X11: Alt+F2 → type 'r' → Enter"
+          echo "   - Wayland: gnome-extensions disable/enable focus-tracker@olbrasoft.cz"
+        else
+          echo "❌ Deployment verification failed"
+          exit 1
+        fi

--- a/.github/workflows/deploy-extension.yml
+++ b/.github/workflows/deploy-extension.yml
@@ -10,6 +10,7 @@ on:
     branches: [main]
     paths:
       - 'gnome-extension/**'
+      - '.github/workflows/deploy-extension.yml'
 
 jobs:
   build:

--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -16,6 +16,8 @@ on:
       - 'src/**'
       - 'tests/**'
       - '*.sln'
+      - 'Directory.Build.props'
+      - '.github/workflows/publish-nuget.yml'
 
 jobs:
   build:

--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -1,11 +1,21 @@
-name: CI/CD
+name: NuGet CI/CD
 
 on:
   push:
     branches: [main]
+    paths:
+      - 'src/**'
+      - 'tests/**'
+      - '*.sln'
+      - 'Directory.Build.props'
+      - '.github/workflows/publish-nuget.yml'
     tags: ['v*']
   pull_request:
     branches: [main]
+    paths:
+      - 'src/**'
+      - 'tests/**'
+      - '*.sln'
 
 jobs:
   build:


### PR DESCRIPTION
## Summary

Separate CI/CD workflows based on changed files:
- **NuGet workflow** triggers only when C# code changes
- **Extension workflow** triggers only when GNOME extension changes

## Changes

### Modified: `.github/workflows/publish-nuget.yml`
- Added `paths` filter to trigger only on:
  - `src/**`, `tests/**`, `*.sln`, `Directory.Build.props`
- Renamed to "NuGet CI/CD" for clarity

### New: `.github/workflows/deploy-extension.yml`
- Triggers only on `gnome-extension/**` changes
- **Build job** (ubuntu-latest): Validates TypeScript compilation
- **Deploy job** (self-hosted): Deploys to `~/.local/share/gnome-shell/extensions/`

## Workflow Triggers

| Changed Files | NuGet Workflow | Extension Workflow |
|---------------|----------------|-------------------|
| `src/**` | ✅ Runs | ❌ Skipped |
| `gnome-extension/**` | ❌ Skipped | ✅ Runs |
| Both | ✅ Runs | ✅ Runs |

## Test plan

- [ ] PR triggers only extension workflow (gnome-extension files changed)
- [ ] Build job passes on ubuntu-latest
- [ ] (After merge) Deploy job runs on self-hosted runner
- [ ] Extension deployed to correct location

Closes #73
Part of #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)