### PR TITLE
docs: Add GNOME extension documentation (#74)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -409,7 +409,7 @@ The extension exposes `org.olbrasoft.Desktop` on the session bus:
 **Extension not loading:**
 ```bash
 # Check GNOME Shell logs
-journalctl -f /usr/bin/gnome-shell
+journalctl -f -u gnome-shell@x11.service
 
 # Verify extension is recognized
 gnome-extensions list | grep focus-tracker

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -319,6 +319,125 @@ public async Task NotifyTaskCompleted(string appName, string message)
 - Accessibility part is experimental
 - API may change
 
+## GNOME Extension Development
+
+### Project Structure
+
+```
+gnome-extension/
+├── src/
+│   ├── extension.ts    # TypeScript source (main extension logic)
+│   └── gjs.d.ts        # Type declarations for GJS/GNOME modules
+├── dist/
+│   └── extension.js    # Generated JavaScript (don't edit directly)
+├── metadata.json       # Extension metadata (UUID, version, shell-version)
+├── package.json        # npm configuration
+├── tsconfig.json       # TypeScript compiler configuration
+└── .gitignore          # Excludes node_modules/ and dist/
+```
+
+### Build Commands
+
+```bash
+cd gnome-extension
+npm install        # Install TypeScript and dependencies
+npm run build      # Compile TypeScript → JavaScript
+npm run watch      # Watch mode - rebuild on file changes
+npm run clean      # Remove dist/ directory
+```
+
+### TypeScript Configuration
+
+The extension uses TypeScript with specific settings for GJS compatibility:
+- **Target:** ES2022 (GJS supports modern JavaScript)
+- **Module:** ES2022 (ES modules)
+- **Strict mode:** Disabled (GJS type system differs from standard TypeScript)
+- **Type declarations:** Custom `gjs.d.ts` for GNOME Shell modules
+
+### CI/CD Pipeline
+
+Two separate GitHub Actions workflows:
+
+| Workflow | Trigger | Purpose |
+|----------|---------|---------|
+| `publish-nuget.yml` | Changes in `src/`, `tests/`, `*.sln` | Build/test .NET, publish NuGet |
+| `deploy-extension.yml` | Changes in `gnome-extension/` | Build TypeScript, deploy extension |
+
+**Extension deployment pipeline:**
+1. Push to `main` triggers workflow
+2. `npm ci` installs dependencies
+3. `npm run build` compiles TypeScript
+4. Deployment job (self-hosted runner) copies to `~/.local/share/gnome-shell/extensions/`
+5. Manual GNOME Shell restart required to load new version
+
+### Manual Deployment
+
+```bash
+# Build
+cd gnome-extension
+npm install
+npm run build
+
+# Deploy
+TARGET=~/.local/share/gnome-shell/extensions/focus-tracker@olbrasoft.cz
+mkdir -p $TARGET
+cp dist/extension.js metadata.json $TARGET/
+
+# Reload extension
+# X11: Alt+F2 → 'r' → Enter
+# Wayland: gnome-extensions disable/enable focus-tracker@olbrasoft.cz
+```
+
+### D-Bus Interface
+
+The extension exposes `org.olbrasoft.Desktop` on the session bus:
+
+**Methods:**
+- `GetPointerPosition() → (ii)` - Cursor coordinates
+- `GetActiveWindowGeometry() → (iiii)` - Window bounds (x, y, w, h)
+- `GetWorkspaceApplications(i) → a(sss)` - Apps on workspace
+
+**Signals:**
+- `WorkspaceChanged(i, i)` - Workspace switch notification
+- `FocusChanged(s, s, s)` - Focus change notification
+
+**Properties:**
+- `CurrentWorkspace`, `TotalWorkspaces`, `ActiveWindow`, `ActiveApplication`
+
+### Troubleshooting
+
+**Extension not loading:**
+```bash
+# Check GNOME Shell logs
+journalctl -f /usr/bin/gnome-shell
+
+# Verify extension is recognized
+gnome-extensions list | grep focus-tracker
+
+# Check extension errors
+gnome-extensions show focus-tracker@olbrasoft.cz
+```
+
+**D-Bus not responding:**
+```bash
+# Test D-Bus interface
+dbus-send --session --print-reply \
+  --dest=org.olbrasoft.Desktop \
+  /org/olbrasoft/Desktop \
+  org.olbrasoft.Desktop.GetPointerPosition
+
+# Check if bus name is registered
+dbus-send --session --print-reply \
+  --dest=org.freedesktop.DBus \
+  /org/freedesktop/DBus \
+  org.freedesktop.DBus.ListNames | grep olbrasoft
+```
+
+**TypeScript compilation errors:**
+- Check `gjs.d.ts` for missing type declarations
+- GJS uses `gi://` module imports (not standard npm packages)
+- Some TypeScript features don't work with GJS runtime
+
 ## References
 
 - **Gemini.md** - Analysis of packaging and system dependencies

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ This library includes a custom GNOME Shell extension (`focus-tracker@olbrasoft.c
 
 **Automated (via CI/CD):**
 
-Extension is automatically deployed to `~/.local/share/gnome-shell/extensions/` after push to `main` branch.
+Extension is automatically deployed to `~/.local/share/gnome-shell/extensions/` after a push to the `main` branch.
 
 **Manual installation:**
 

--- a/README.md
+++ b/README.md
@@ -171,6 +171,81 @@ if (activeWindow.Application != "claude-code")
 }
 ```
 
+## GNOME Shell Extension
+
+This library includes a custom GNOME Shell extension (`focus-tracker@olbrasoft.cz`) that provides D-Bus APIs for desktop context awareness.
+
+### D-Bus Interface
+
+**Bus name:** `org.olbrasoft.Desktop`
+**Object path:** `/org/olbrasoft/Desktop`
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `GetPointerPosition` | `() → (ii)` | Returns cursor (x, y) coordinates |
+| `GetActiveWindowGeometry` | `() → (iiii)` | Returns window (x, y, width, height) |
+| `GetWorkspaceApplications` | `(i) → a(sss)` | Returns apps on workspace (appId, title, wmClass) |
+
+| Signal | Args | Description |
+|--------|------|-------------|
+| `WorkspaceChanged` | `(i, i)` | Emitted on workspace switch (newIndex, total) |
+| `FocusChanged` | `(s, s, s)` | Emitted on focus change (title, appId, wmClass) |
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `CurrentWorkspace` | `i` | Active workspace index (0-based) |
+| `TotalWorkspaces` | `i` | Number of workspaces |
+| `ActiveWindow` | `s` | Focused window title |
+| `ActiveApplication` | `s` | Focused application ID |
+
+### Installation
+
+**Automated (via CI/CD):**
+
+Extension is automatically deployed to `~/.local/share/gnome-shell/extensions/` after push to `main` branch.
+
+**Manual installation:**
+
+```bash
+cd gnome-extension
+npm install
+npm run build
+mkdir -p ~/.local/share/gnome-shell/extensions/focus-tracker@olbrasoft.cz
+cp dist/extension.js metadata.json ~/.local/share/gnome-shell/extensions/focus-tracker@olbrasoft.cz/
+```
+
+### Development
+
+```bash
+cd gnome-extension
+npm install        # Install dependencies
+npm run build      # Build TypeScript → JavaScript
+npm run watch      # Rebuild on changes (development)
+npm run clean      # Remove dist/
+```
+
+### Extension Reload
+
+After deployment, reload the extension:
+
+- **X11:** Alt+F2 → type `r` → Enter
+- **Wayland:** `gnome-extensions disable focus-tracker@olbrasoft.cz && gnome-extensions enable focus-tracker@olbrasoft.cz`
+
+Or log out and back in.
+
+### Verify Extension
+
+```bash
+# Check extension is enabled
+gnome-extensions list --enabled | grep focus-tracker
+
+# Test D-Bus interface
+dbus-send --session --print-reply \
+  --dest=org.olbrasoft.Desktop \
+  /org/olbrasoft/Desktop \
+  org.olbrasoft.Desktop.GetPointerPosition
+```
+
 ## Related Projects
 
 - [VirtualAssistant](https://github.com/Olbrasoft/VirtualAssistant) - Primary consumer of this library


### PR DESCRIPTION
## Summary

- **README.md**: Added comprehensive GNOME Shell Extension section with D-Bus interface documentation
- **CLAUDE.md**: Added GNOME Extension Development section with build workflow and troubleshooting guide

## Changes

### README.md
- D-Bus interface specification (methods, signals, properties)
- Installation instructions (automated CI/CD and manual)
- Development commands (npm build/watch/clean)
- Extension reload instructions (X11/Wayland)
- Verification commands

### CLAUDE.md
- Project structure documentation
- TypeScript configuration and GJS compatibility notes
- CI/CD pipeline documentation (separate workflows)
- Troubleshooting guide for common issues

## Test plan

- [ ] Documentation renders correctly on GitHub
- [ ] All commands work as documented
- [ ] Links are valid

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)